### PR TITLE
Store protected probe ID between reloads

### DIFF
--- a/src/components/panels/ProbingPanel.vue
+++ b/src/components/panels/ProbingPanel.vue
@@ -84,7 +84,6 @@ export default defineComponent({
 
     data() {
         return {
-            currentWorkplace: 0,
             probeTypes: probeTypes,
             selectedProbeType: -1,
             probeSettings: null as ProbeCommand | null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,4 @@ registerRoute(Dash, {
 	}
 });
 
-registerPluginData('MillenniumOS', PluginDataType.machineSetting, 'protectedMoveProbeID', -1);
+registerPluginData('MillenniumOS', PluginDataType.machineCache, 'protectedMoveProbeID', -1);

--- a/src/types/MachineCache.ts
+++ b/src/types/MachineCache.ts
@@ -1,0 +1,4 @@
+export type MachineCache = {
+    // Previously selected probe ID
+    protectedMoveProbeID: number;
+}


### PR DESCRIPTION
This remembers the previously selected protected move probe, selecting it by default when DWC is reloaded.