### PR TITLE
Add Web and Pocket X/Y Probe Cycle Configurations

### DIFF
--- a/src/MillenniumOS.vue
+++ b/src/MillenniumOS.vue
@@ -24,11 +24,12 @@
                 <mos-job-progress-panel class="mb-2" />
             </v-col>
         </v-row> -->
+
         <v-row>
-            <v-col cols="9" class="pb-0">
+            <v-col cols="8" class="pb-0">
                 <mos-probing-panel class="mb-2 fill-height" />
             </v-col>
-            <v-col cols="3" class="pb-0">
+            <v-col cols="4" class="pb-0">
                 <mos-workplace-origins-panel class="mb-2 fill-height" />
             </v-col>
         </v-row>

--- a/src/components/BaseComponent.vue
+++ b/src/components/BaseComponent.vue
@@ -54,8 +54,8 @@
             return {}
         },
         methods: {
-            async sendCode(code: string) {
-                await store.dispatch("machine/sendCode", code);
+            async sendCode(code: string): Promise<string> {
+                return await store.dispatch("machine/sendCode", code);
             },
         }
     });

--- a/src/components/panels/ProbeSettingsPanel.vue
+++ b/src/components/panels/ProbeSettingsPanel.vue
@@ -80,7 +80,7 @@
                                                     v-model="setting.value"
                                                     mandatory
                                                     column
-                                                    class="ml-4 px-0 py-0"
+                                                    class="ml-4 px-0 py-0 mt-n3"
                                                     >
                                                 <v-tooltip v-for="(option, i) in setting.options" :key="i" top>
                                                     <template v-slot:activator="{ on, attrs }">
@@ -91,9 +91,10 @@
                                                             :color="getEnumColor(i, setting.value)"
                                                             :disabled="!allowInput(name)"
                                                             label
-                                                            class="mt-0 mb-0"
+                                                            small
+                                                            class="mt-2 mb-0 pl-0 pr-1"
                                                             >
-                                                            <v-icon>{{ getEnumIcon(option) }}</v-icon>
+                                                            <v-icon class="px-0">{{ getEnumIcon(option) }}</v-icon>
                                                             {{ getEnumText(option) }}
                                                         </v-chip>
                                                     </template>

--- a/src/components/panels/ProbeSettingsPanel.vue
+++ b/src/components/panels/ProbeSettingsPanel.vue
@@ -76,28 +76,30 @@
                                         <v-input
                                             :prepend-icon="setting.icon"
                                         >
-                                            <v-btn-toggle
+                                            <v-chip-group
                                                     v-model="setting.value"
                                                     mandatory
-                                                    class="ml-4"
+                                                    column
+                                                    class="ml-4 px-0 py-0"
                                                     >
                                                 <v-tooltip v-for="(option, i) in setting.options" :key="i" top>
                                                     <template v-slot:activator="{ on, attrs }">
-                                                        <v-btn
+                                                        <v-chip
                                                             v-on="on"
                                                             :key="i"
                                                             :value="i"
                                                             :color="getEnumColor(i, setting.value)"
                                                             :disabled="!allowInput(name)"
-                                                            small
+                                                            label
+                                                            class="mt-0 mb-0"
                                                             >
                                                             <v-icon>{{ getEnumIcon(option) }}</v-icon>
                                                             {{ getEnumText(option) }}
-                                                        </v-btn>
+                                                        </v-chip>
                                                     </template>
                                                     <span>{{ getEnumText(option) }}</span>
                                                 </v-tooltip>
-                                            </v-btn-toggle>
+                                            </v-chip-group>
                                         </v-input>
                                     </v-col>
                                     <v-col cols="4" md="2" class="text-right">

--- a/src/components/panels/ProbingPanel.vue
+++ b/src/components/panels/ProbingPanel.vue
@@ -306,7 +306,14 @@ export default defineComponent({
             this.probing = true;
             await this.sendCode("M5012");
             this.nextStep();
-            await this.sendCode([this.getProbeCode(), "M5012"].join("\n"));
+            const reply = await this.sendCode(this.getProbeCode());
+
+            if(reply.length > 0) {
+                this.tab = (this.probeActive ? 1 : 0);
+                this.probing = false;
+            }
+
+            await this.sendCode("M5012");
         },
     },
     mounted() {

--- a/src/components/panels/WorkplaceOriginsPanel.vue
+++ b/src/components/panels/WorkplaceOriginsPanel.vue
@@ -5,7 +5,7 @@
     .v-data-table >>> .v-data-table__wrapper > table > thead > tr > th,
     .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > td,
     .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > th {
-    padding: 0 2px;
+    padding: 0 8px;
     }
 </style>
 <template>
@@ -106,6 +106,16 @@
             visibleAxesLetters(): Array<string> {
                 return this.visibleAxes.map(axis => axis.letter);
             },
+            axisHeaders(): Array<any> {
+                return this.visibleAxes.map(axis => ({
+                    text: axis.letter,
+                    value: axis.letter,
+                    align: 'center',
+                }));
+            },
+            headers(): Array<any> {
+                return this.headersPrepend.concat(this.axisHeaders, this.headersAppend);
+            },
             items(): Array<any> {
                 const workplaces = store.state.machine.model.limits?.workplaces ?? 0;
                 return Array.from({ length: workplaces }, (_, w) => {
@@ -126,7 +136,7 @@
         data() {
             return {
                 selectedWorkplace: -1,
-                headers: [{
+                headersPrepend: [{
                     text: 'Workplace',
                     value: 'workplace',
                     align: 'start',
@@ -134,11 +144,8 @@
                     text: this.$t('plugins.millenniumos.panels.workplaceOrigins.activeHeader'),
                     value: 'active',
                     align: 'center',
-                }, ...store.state.machine.model.move.axes.map(axis => ({
-                    text: axis.letter,
-                    value: axis.letter,
-                    align: 'center',
-                })), {
+                }],
+                headersAppend: [{
                     text: '',
                     value: 'actions',
                     align: 'end',

--- a/src/types/Probe.ts
+++ b/src/types/Probe.ts
@@ -1,12 +1,23 @@
 const DS_OVERTRAVEL = 'overtravel';
 const DS_SURFACE_CLEARANCE = 'surface-clearance';
+const DS_EDGE_CLEARANCE = 'edge-clearance';
 const DS_CORNER_CLEARANCE = 'corner-clearance';
+const DS_QUICK = 'quick';
 
 export const valueSettings = {
+
+    [DS_QUICK]: {
+        type: 'boolean',
+        label: 'Quick Mode',
+        description: 'If enabled, only a single probe point will be performed on each surface. Angle calculations will not be performed. Turn this off for more accurate probe results.',
+        parameter: 'Q',
+        icon: 'mdi-clock-fast',
+        value: true,
+    },
     [DS_OVERTRAVEL]: {
         type: 'number',
         label: 'Overtravel',
-        description: 'The distance the probe will travel past the expected edge of the workpiece, to account for inaccuracies in the starting position or feature dimensions.',
+        description: 'The distance the probe will travel past the expected edge of the feature or workpiece, to account for inaccuracies in the starting position or feature dimensions.',
         parameter: 'O',
         icon: 'mdi-unfold-less-vertical',
         value: 2,
@@ -18,7 +29,7 @@ export const valueSettings = {
     [DS_SURFACE_CLEARANCE]: {
         type: 'number',
         label: 'Surface Clearance',
-        description: 'The distance the probe will move inwards towards the expected surface of the workpiece, to account for inaccuracies in the starting position or work holding.',
+        description: 'The distance the probe will move inwards towards the expected surface of the feature or workpiece, to account for inaccuracies in the starting position or work holding.',
         parameter: 'T',
         icon: 'mdi-unfold-more-vertical',
         value: 10,
@@ -30,7 +41,7 @@ export const valueSettings = {
     [DS_CORNER_CLEARANCE]: {
         type: 'number',
         label: 'Corner Clearance',
-        description: 'The distance the probe will move inwards from the expected corner of the workpiece, to account for inaccuracies in the starting position or corner radiuses.',
+        description: 'The distance the probe will move inwards from the expected corner of the feature or workpiece, to account for inaccuracies in the starting position or corner radiuses.',
         parameter: 'C',
         icon: 'mdi-unfold-more-horizontal',
         value: 5,
@@ -38,6 +49,20 @@ export const valueSettings = {
         max: 50,
         step: 0.1,
         unit: 'mm'
+    },
+    [DS_EDGE_CLEARANCE]: {
+        type: 'number',
+        label: 'Edge Clearance',
+        description: 'The distance the probe will move inwards from the expected edge of the feature or workpiece, to account for inaccuracies in the starting position.',
+        parameter: 'C',
+        icon: 'mdi-unfold-more-horizontal',
+        value: 5,
+        min: 1,
+        max: 50,
+        step: 0.1,
+        unit: 'mm',
+        condition: 'quick',
+        conditionValue: false,
     }
 };
 
@@ -160,6 +185,11 @@ export class ProbeCommand implements IProbeCommand {
 
             // Dont include settings without a parameter
             if (setting.parameter === undefined) {
+                continue;
+            }
+
+            // Dont include settings that are disabled
+            if (setting.condition && setting.conditionValue === false) {
                 continue;
             }
 
@@ -374,6 +404,75 @@ export default {
             [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
         },
     },
+    web: <ProbeType> {
+        name: 'Web',
+        icon: 'mdi-math-norm-box',
+        description: 'Finds the center of a web (positive rectangular feature) on one axis by probing its outer surfaces.',
+        code: 6504.1,
+        settings: {
+            [DS_QUICK]: valueSettings[DS_QUICK],
+            'axis': {
+                type: 'enum',
+                label: 'Axis',
+                description: 'The axis of the web.',
+                parameter: 'N',
+                icon: 'mdi-axis-arrow',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-swap-horizontal',
+                        label: 'X'
+                    },
+                    {
+                        icon: 'mdi-swap-vertical',
+                        label: 'Y'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate width of the web. This is how far outwards we will move before probing back towards the web surfaces.',
+                parameter: 'H',
+                icon: 'mdi-unfold-less-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the web surfaces.',
+                parameter: 'I',
+                icon: 'mdi-unfold-less-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_EDGE_CLEARANCE]: valueSettings[DS_EDGE_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        }
+    },
     outsideCorner: <ProbeType> {
         name: 'Outside Corner',
         icon: 'mdi-square-rounded-badge',
@@ -381,14 +480,7 @@ export default {
         code: 6508.1,
         // G6508.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.cnr} T{var.SurfaceClearance} C{var.cornerClearance} O{var.overtravel} J{global.mosMI[0]} K{global.mosMI[1]} L{global.mosMI[2] - var.probingDepth}
         settings: {
-            'quick': {
-                type: 'boolean',
-                label: 'Quick Mode',
-                description: 'If enabled, only a single probe point will be performed on the surfaces forming the corner. Rotation compensation will not be available.',
-                parameter: 'Q',
-                icon: 'mdi-clock-fast',
-                value: false
-            },
+            [DS_QUICK]: { ...valueSettings[DS_QUICK], value: false },
             'corner': {
                 type: 'enum',
                 label: 'Corner',
@@ -467,14 +559,7 @@ export default {
         description: 'Finds the top and corner of a positive feature or workpiece by probing its top and outer surfaces.',
         code: 6520.1,
         settings: {
-            'quick': {
-                type: 'boolean',
-                label: 'Quick Mode',
-                description: 'If enabled, only a single probe point will be performed on the surfaces forming the corner. Rotation compensation will not be available.',
-                parameter: 'Q',
-                icon: 'mdi-clock-fast',
-                value: false
-            },
+            [DS_QUICK]: valueSettings[DS_QUICK],
             'corner': {
                 type: 'enum',
                 label: 'Corner',

--- a/src/types/Probe.ts
+++ b/src/types/Probe.ts
@@ -188,8 +188,9 @@ export class ProbeCommand implements IProbeCommand {
                 continue;
             }
 
-            // Dont include settings that are disabled
-            if (setting.condition && setting.conditionValue === false) {
+            // Dont include settings whose conditional setting does
+            // not match the conditionValue.
+            if (setting.condition && this.settings[setting.condition].value !== setting.conditionValue) {
                 continue;
             }
 
@@ -432,7 +433,7 @@ export default {
             'width': {
                 type: 'number',
                 label: 'Width',
-                description: 'The approximate width of the web. This is how far outwards we will move before probing back towards the web surfaces.',
+                description: 'The approximate width of the web. This is how far outwards along the probed axis we will move before probing back towards the web surfaces.',
                 parameter: 'H',
                 icon: 'mdi-unfold-less-vertical',
                 value: 10,
@@ -444,7 +445,7 @@ export default {
             'length': {
                 type: 'number',
                 label: 'Length',
-                description: 'The approximate length of the web surfaces.',
+                description: 'The approximate length of the web surfaces. With quick mode disabled, this is used to calculate the probe locations on the web surfaces.',
                 parameter: 'I',
                 icon: 'mdi-unfold-less-horizontal',
                 value: 10,

--- a/src/types/Probe.ts
+++ b/src/types/Probe.ts
@@ -474,6 +474,75 @@ export default {
             [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
         }
     },
+    pocket: <ProbeType> {
+        name: 'Pocket',
+        icon: 'mdi-math-norm',
+        description: 'Finds the center of a pocket (negative rectangular feature) on one axis by probing its inner surfaces.',
+        code: 6505.1,
+        settings: {
+            [DS_QUICK]: valueSettings[DS_QUICK],
+            'axis': {
+                type: 'enum',
+                label: 'Axis',
+                description: 'The axis of the pocket.',
+                parameter: 'N',
+                icon: 'mdi-axis-arrow',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-swap-horizontal',
+                        label: 'X'
+                    },
+                    {
+                        icon: 'mdi-swap-vertical',
+                        label: 'Y'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate width of the pocket. This defines how far outwards we expect the probed surfaces to be from the start point, minus the clearance distance.',
+                parameter: 'H',
+                icon: 'mdi-unfold-less-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the pocket surfaces. With quick mode disabled, this is used to calculate the probe locations on the pocket surfaces.',
+                parameter: 'I',
+                icon: 'mdi-unfold-less-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_EDGE_CLEARANCE]: valueSettings[DS_EDGE_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        }
+    },
     outsideCorner: <ProbeType> {
         name: 'Outside Corner',
         icon: 'mdi-square-rounded-badge',


### PR DESCRIPTION
Switch to using a chip group for probe enums.

Deduplicate the quick parameter, add edge clearance for Web and Pocket, and clean up conditionals.